### PR TITLE
DLW Resolver deploy fix

### DIFF
--- a/deadletter_resolver/serverless.yml
+++ b/deadletter_resolver/serverless.yml
@@ -18,14 +18,9 @@ functions:
       - http:
           path: resolve
           method: post
-    iamRoleStatements:
-      - Effect: "Allow"
-        Action: "secretsmanager:GetSecretValue"
-        Resource: "arn:aws:secretsmanager:eu-west-2:*:secret:deadletter-watcher-secrets-XOWbaE"
 
 plugins:
   - serverless-python-requirements
-  - serverless-iam-roles-per-function
 
 custom:
   pythonRequirements:


### PR DESCRIPTION
Fix for deployment error 
https://github.com/glasswall-sre/dead-letter-watcher/runs/1331319038?check_suite_focus=true

Dropped **iam-roles-per-function** requirement as its not required for now.